### PR TITLE
Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,0 +1,70 @@
+name: Report a bug
+description: Report a bug to help improve EOCLU.
+title: "Please Enter a Short, Descriptive Title"
+labels: ["bug"]
+assignees:
+  - LibertyNJ
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out a bug report! If EOCLU
+        prompted you to include any details, be sure to do so. If you are
+        reporting a security vulnerability, please do not complete this bug
+        report. See the
+        [security policy](https://github.com/LibertyNJ/eoclu?tab=security-ov-file#readme)
+        instead.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        Which version of EOCLU are you running? (run eoclu --version)
+    validations:
+      required: true
+  - type: dropdown
+    id: distribution
+    attributes:
+      label: Distribution
+      description: Which distribution of EOCLU are you running?
+      options:
+        - Built from source
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: Command
+      description: |
+        What command did you run?  (e.g., eoclu get-character --name "Isamon
+        Itinen" --debug)
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Describe the scenario and provide as many details as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Copy and paste any relevant log output.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: |
+        By submitting this bug report, you agree to follow our
+        [Code of Conduct](https://github.com/LibertyNJ/eoclu?tab=coc-ov-file#readme).
+      options:
+        - label: I agree to follow this project’s Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,0 +1,36 @@
+name: Request a feature
+description: Suggest an idea for EOCLU.
+title: "Please Enter a Short, Descriptive Title"
+labels: ["enhancement"]
+assignees:
+  - LibertyNJ
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to suggest a feature! It will be reviewed,
+        but there is no guarantee that it will be implemented.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the problem that you’d like to solve.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Describe your ideal solution to the problem.
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: | 
+        By submitting this feature request, you agree to follow our
+        [Code of Conduct](https://github.com/LibertyNJ/eoclu?tab=coc-ov-file#readme). 
+      options:
+        - label: I agree to follow this project’s Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    about: Ask a question about EOCLU in discussions.
+    url: https://github.com/LibertyNJ/eoclu/discussions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Please describe the changes in this pull request in a way that is
+suitable to be the commit message when it is squashed and merged. The
+title of the pull request should be in sentence case without a
+terminating period and be no longer than 50 characters. The description
+should break lines at 72 characters.


### PR DESCRIPTION
GitHub form templates provide structured forms for contributors to
submit bug reports and feature requests. The pull request template
provides guidance on the expected format for pull request titles and
descriptions.

Also displays a link for contributors to ask questions in GitHub
discussions if it is more suitable for their use than a bug report or
feature request.
