### PR TITLE
Add community documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+nathaniel.liberty@gmail.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org/), version 2.1,
+available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq/>. Translations are available at
+<https://www.contributor-covenant.org/translations/>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,3 +26,8 @@ Please check if the
 [feature has already been requested](https://github.com/LibertyNJ/eoclu/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement)
 first. If it has not,
 [request a feature here](https://github.com/LibertyNJ/eoclu/issues/new?template=FEATURE_REQUEST.yml).
+
+## Discussions
+
+You can ask questions and engage with others about the project in
+[discussions](https://github.com/LibertyNJ/eoclu/discussions).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,9 @@ Thank you for your interest in contributing to EOCLU.
 
 All contributors are expected to abide by the
 [code of conduct](CODE_OF_CONDUCT.md).
+
+## Security Vulnerabilities
+
+If you believe that you have found a security vulnerability,
+**do not open a bug report**. Please follow the instructions in the
+[security policy](SECURITY.md) instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,10 @@ All contributors are expected to abide by the
 If you believe that you have found a security vulnerability,
 **do not open a bug report**. Please follow the instructions in the
 [security policy](SECURITY.md) instead.
+
+## Bug Reports
+
+Please check if the
+[bug has already been reported](https://github.com/LibertyNJ/eoclu/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
+first. If it has not,
+[report a bug here](https://github.com/LibertyNJ/eoclu/issues/new?template=BUG_REPORT.yml).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,10 @@ Please check if the
 [bug has already been reported](https://github.com/LibertyNJ/eoclu/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
 first. If it has not,
 [report a bug here](https://github.com/LibertyNJ/eoclu/issues/new?template=BUG_REPORT.yml).
+
+## Feature Requests
+
+Please check if the
+[feature has already been requested](https://github.com/LibertyNJ/eoclu/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement)
+first. If it has not,
+[request a feature here](https://github.com/LibertyNJ/eoclu/issues/new?template=FEATURE_REQUEST.yml).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+Thank you for your interest in contributing to EOCLU.
+
+## Code of Conduct
+
+All contributors are expected to abide by the
+[code of conduct](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,3 +10,11 @@ actively supported.
 | Version | Supported |
 | ------- | --------- |
 | 0.x.x   | Yes       |
+
+## Reporting a Vulnerability
+
+If you have identified a vulnerability, please
+[report it privately here](https://github.com/LibertyNJ/eoclu/security/advisories/new).
+The maintainers of the project will be in touch with you as soon as possible.
+Legitimate vulnerabilities will be acted upon and disclosed publicly. Thank you
+for your discretion.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+Thank you for doing your part to help keep EOCLU safe and secure.
+
+## Supported Versions
+
+This project is currently in early development. Only the latest minor release is
+actively supported.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.x.x   | Yes       |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,4 @@
+# Support
+
+For questions or help using EOCLU, visit
+[discussions](https://github.com/LibertyNJ/eoclu/discussions).


### PR DESCRIPTION
Adds basic documentation including contributing guidelines, a code of
conduct, guidance towards getting support for the project, and a
security policy.
