### PR TITLE
Remove invalid attribute from bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -41,7 +41,6 @@ body:
       description: |
         What command did you run?  (e.g., eoclu get-character --name "Isamon
         Itinen" --debug)
-      render: shell
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -28,9 +28,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: | 
+      description: |
         By submitting this feature request, you agree to follow our
-        [Code of Conduct](https://github.com/LibertyNJ/eoclu?tab=coc-ov-file#readme). 
+        [Code of Conduct](https://github.com/LibertyNJ/eoclu?tab=coc-ov-file#readme).
       options:
         - label: I agree to follow this project’s Code of Conduct.
           required: true


### PR DESCRIPTION
The "render" attribute is only allowed in "textarea" types.
