### PR TITLE
Improve issue form instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -1,6 +1,5 @@
 name: Report a bug
 description: Report a bug to help improve EOCLU.
-title: "Please Enter a Short, Descriptive Title"
 labels: ["bug"]
 assignees:
   - LibertyNJ
@@ -8,10 +7,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to fill out a bug report! If EOCLU
-        prompted you to include any details, be sure to do so. If you are
-        reporting a security vulnerability, please do not complete this bug
-        report. See the
+        Thank you for taking the time to fill out a bug report! Please enter a
+        short, descriptive title above. If EOCLU prompted you to include any
+        details, be sure to do so. If you are reporting a security
+        vulnerability, please do not complete this bug report. See the
         [security policy](https://github.com/LibertyNJ/eoclu?tab=security-ov-file#readme)
         instead.
   - type: input

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -7,12 +7,14 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to fill out a bug report! Please enter a
-        short, descriptive title above. If EOCLU prompted you to include any
-        details, be sure to do so. If you are reporting a security
-        vulnerability, please do not complete this bug report. See the
-        [security policy](https://github.com/LibertyNJ/eoclu?tab=security-ov-file#readme)
-        instead.
+        Thank you for taking the time to fill out a bug report!
+
+        Please enter a short, descriptive title above.
+
+        If you are reporting a security vulnerability, please do not complete this bug
+        report. See the [security policy](https://github.com/LibertyNJ/eoclu?tab=security-ov-file#readme) instead.
+
+        If EOCLU prompted you to include any details, please be sure to include them below.
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -7,9 +7,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to suggest a feature! Please enter a
-        short, descriptive title above. The request will be reviewed, but there
-        is no guarantee that it will be implemented.
+        Thank you for taking the time to suggest a feature!
+
+        Please enter a short, descriptive title above.
+
+        The request will be reviewed, but there is no guarantee that it will be
+        implemented.
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yml
@@ -1,6 +1,5 @@
 name: Request a feature
 description: Suggest an idea for EOCLU.
-title: "Please Enter a Short, Descriptive Title"
 labels: ["enhancement"]
 assignees:
   - LibertyNJ
@@ -8,8 +7,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to suggest a feature! It will be reviewed,
-        but there is no guarantee that it will be implemented.
+        Thank you for taking the time to suggest a feature! Please enter a
+        short, descriptive title above. The request will be reviewed, but there
+        is no guarantee that it will be implemented.
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
Adjusts form instructions to be easier to read. Also replaces default
issue titles with instructions to create an issue title. This is done to
discourage collaborators from simply submitting the form with the
default title.
