### PR TITLE
Add sponsorship options

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+custom: ['https://www.eveonline.com/signup?invc=a38afdc3-ebe1-4710-bae2-221c4efaf1e3'] 
+ko_fi: nathanieljliberty


### PR DESCRIPTION
Configures Ko-fi and the EVE Online recruit-a-friend program as
sponsorship options for contributors interested in supporting
maintenance of the project.
