### PR TITLE
Maintain a changelog

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,16 +7,6 @@ changelog:
 documentation:
   - changed-files:
       - any-glob-to-any-file: "*.md"
-feature:
-  - all:
-    - changed-files:
-      - any-glob-to-any-file: ["Cargo.toml", "Cargo.lock", "src/**/*"]
-    - head-branch: ["^feature"]
-fix:
-  - all:
-    - changed-files:
-      - any-glob-to-any-file: ["Cargo.toml", "Cargo.lock", "src/**/*"]
-    - head-branch: ["^fix"]
 git:
   - changed-files:
       - any-glob-to-any-file: ".gitignore"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,16 +32,19 @@ first. If it has not,
 You can ask questions and engage with others about the project in
 [discussions](https://github.com/LibertyNJ/eoclu/discussions).
 
-## Branch Naming Conventions
+## Maintaining the Changelog
 
-Branch names should be in `kebab-case`.
+All changes to features, deprecations of features, bug fixes, and security
+patches should be recorded in [CHANGELOG.md](CHANGELOG.md), which follows the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) guidelines.
 
-### Prefixes
+All breaking changes should be prefixed with "**BREAKING**: ", and moved to the
+beginning of their respective sections.
 
-Branches that impact the functionality of EOCLU in a way that is noticeable to
-users should follow the prefix conventions below.
+For example:
 
-| Impact                 | Prefix     |
-| ---------------------- | ---------- |
-| Bug fix                | `fix-`     |
-| Feature implementation | `feature-` |
+```markdown
+### Changed
+
+- **BREAKING**: Made a backward incompatible change to a public interface.
+```


### PR DESCRIPTION
Begins a human-readable changelog. Replaces guidance on branch names
with direction to maintain the changelog. Removes feature and fix branch
label automation.
