### PR TITLE
Correct path to extract-release-notes action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,13 +3,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - .github/workflows/continuous-integration.yml
-      - '**.rs'
-      - '**.snap'
-      - Cargo.lock
-      - Cargo.toml
-      - rust-toolchain.toml
   workflow_call:
     inputs:
       branch-name:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Extract Release Notes
         id: extract-release-notes
-        uses: ./github/actions/extract-release-notes
+        uses: ./.github/actions/extract-release-notes
       - name: Determine Release Level
         id: determine-release-level
         uses: ./.github/actions/determine-release-level


### PR DESCRIPTION
Adds a missing "." character in the path to the extract-release-notes
action in the release workflow. Also makes continuous integration run on
all pull requests due to GitHub not being satisfied by non-matching
paths with required checks.
