### PR TITLE
Correct passing passphrase to GPG

### DIFF
--- a/.github/actions/configure-gpg-and-git/action.yml
+++ b/.github/actions/configure-gpg-and-git/action.yml
@@ -32,8 +32,7 @@ runs:
         gpgconf --launch gpg-agent
         echo "${{ inputs.gpg-private-key }}" | gpg --batch --import
         KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/{print $5}' | head -n1)
-        echo "${{ inputs.gpg-passphrase }}" | \
-        gpg --batch --pinentry-mode loopback --passphrase-fd 0 \
+        gpg --batch --pinentry-mode loopback --passphrase "${{ inputs.gpg-passphrase }}" \
         --sign --default-key "$KEY_ID" --output /dev/null <<< "preload"
         echo "$KEY_ID:6:" | gpg --import-ownertrust
         echo "key-id=$KEY_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Passes the GPG key passphrase by named parameter instead of pipe.
