### PR TITLE
Run CI in release mode from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
     uses: ./.github/workflows/continuous-integration.yml
     with:
       branch-name: ${{ needs.create-release-branch.outputs.release-branch-name }}
+      release: true
   package:
     name: Package ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Running continuous integration in release mode causes it to upload the
build artifacts for packaging by the release workflow.
