### PR TITLE
Correct individual artifact download paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
         if: matrix.runner != 'windows-latest'
         run: |
           mkdir dist
-          cp ${{ steps.download-build-artifact.outputs.download-path }}/${{ matrix.artifact-name }}/eoclu dist/
+          cp ${{ steps.download-build-artifact.outputs.download-path }} dist/
           cp CHANGELOG.md LICENSE-* README.md dist/
           tar -czvf "${{ steps.determine-archive-name.outputs.archive-file-name }}" \
             -C dist .
@@ -146,7 +146,7 @@ jobs:
         if: matrix.runner == 'windows-latest'
         run: |
           New-Item -ItemType Directory -Path dist
-          Copy-Item -Path ${{ steps.download-build-artifact.outputs.download-path }}\${{ matrix.artifact-name }}\eoclu.exe -Destination dist\
+          Copy-Item -Path ${{ steps.download-build-artifact.outputs.download-path }} -Destination dist\
           Get-ChildItem -Path LICENSE-* | Copy-Item -Destination dist\
           Copy-Item -Path CHANGELOG.md -Destination dist\
           Copy-Item -Path README.md -Destination dist\


### PR DESCRIPTION
Download artifact does not nest artifacts in a directory behind the
artifact name when specifying a single artifact.