### PR TITLE
Correct release job details

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Fetch Release Branch
         run: git fetch origin ${{ needs.create-release-branch.outputs.release-branch-name }}
       - name: Merge Release Branch
-        run: git merge ${{ needs.create-release-branch.outputs.release-branch-name }} --ff-only
+        run: git merge FETCH_HEAD --ff-only
       - name: Create Tag
         run: |
           git tag --sign ${{ needs.create-release-branch.outputs.release-tag-name }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,6 @@ jobs:
           discussion_category_name: Releases
           fail_on_unmatched_files: true
           files: ./packages/*
-          generate_release_notes: true
           name: ${{ needs.create-release-branch.outputs.release-version }}
           preserve_order: true
           tag_name: ${{ needs.create-release-branch.outputs.release-tag-name }}


### PR DESCRIPTION
Merges FETCH_HEAD to main instead of the rellease branch itself which
does not exist locally. Opts out of automatic release note generation in
favor of excerpt from the changelog.