### PR TITLE
Permit release job to write discussions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
     permissions:
       attestations: write
       contents: write
+      discussions: write
       id-token: write
     needs:
       - create-release-branch


### PR DESCRIPTION
The GitHub release action requires discussion write permission to create
a discussion for the release.