### PR TITLE
Make unix binaries executable by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,7 @@ jobs:
         run: |
           mkdir dist
           cp build/eoclu dist/
+          chmod +x dist/eoclu
           cp CHANGELOG.md LICENSE-* README.md dist/
           tar -czvf "${{ steps.determine-archive-name.outputs.archive-file-name }}" \
             -C dist .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Binary is executable by default on unix-like platforms.
+
 ## [0.1.0] - 2025-08-24
 
 ### Added
@@ -13,4 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Concise help text is displayed when passed the `-h` flag.
 - Version is displayed when passed the `--version` or `-V` flags.
 
+[unreleased]: https://github.com/libertynj/eoclu/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/libertynj/eoclu/compare/5255e1d60f2643f6c2c2d624b8e1689a0f53f612...v0.1.0


### PR DESCRIPTION
The executable status of an artifact downloaded during GitHub actions is
not preserved. It is necessary to manually set the executable bit before
packaging. The executable bit should be preserved in the archive.
